### PR TITLE
Changed GroupId and renamed packages

### DIFF
--- a/liberty-mongodb/pom.xml
+++ b/liberty-mongodb/pom.xml
@@ -2,7 +2,7 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.eclipse.jnosql.demoee</groupId>
+  <groupId>org.jnosql.demoee</groupId>
   <artifactId>liberty-mongodb</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>war</packaging>

--- a/liberty-mongodb/src/main/java/org/jnosql/demoee/liberty/mongodb/HelloController.java
+++ b/liberty-mongodb/src/main/java/org/jnosql/demoee/liberty/mongodb/HelloController.java
@@ -1,4 +1,4 @@
-package org.eclipse.jnosql.demoee.liberty.mongodb;
+package org.jnosql.demoee.liberty.mongodb;
 
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;

--- a/liberty-mongodb/src/main/java/org/jnosql/demoee/liberty/mongodb/LibertymongodbRestApplication.java
+++ b/liberty-mongodb/src/main/java/org/jnosql/demoee/liberty/mongodb/LibertymongodbRestApplication.java
@@ -1,4 +1,4 @@
-package org.eclipse.jnosql.demoee.liberty.mongodb;
+package org.jnosql.demoee.liberty.mongodb;
 
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;

--- a/liberty-mongodb/src/main/java/org/jnosql/demoee/liberty/mongodb/Person.java
+++ b/liberty-mongodb/src/main/java/org/jnosql/demoee/liberty/mongodb/Person.java
@@ -1,4 +1,4 @@
-package org.eclipse.jnosql.demoee.liberty.mongodb;
+package org.jnosql.demoee.liberty.mongodb;
 
 import jakarta.nosql.Column;
 import jakarta.nosql.Entity;

--- a/liberty-mongodb/src/main/java/org/jnosql/demoee/liberty/mongodb/PersonController.java
+++ b/liberty-mongodb/src/main/java/org/jnosql/demoee/liberty/mongodb/PersonController.java
@@ -1,4 +1,4 @@
-package org.eclipse.jnosql.demoee.liberty.mongodb;
+package org.jnosql.demoee.liberty.mongodb;
 
 
 import jakarta.inject.Inject;

--- a/liberty-mongodb/src/main/java/org/jnosql/demoee/liberty/mongodb/PersonRepository.java
+++ b/liberty-mongodb/src/main/java/org/jnosql/demoee/liberty/mongodb/PersonRepository.java
@@ -1,4 +1,4 @@
-package org.eclipse.jnosql.demoee.liberty.mongodb;
+package org.jnosql.demoee.liberty.mongodb;
 
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Repository;

--- a/liberty-mongodb/src/main/java/org/jnosql/demoee/liberty/mongodb/config/ConfigTestController.java
+++ b/liberty-mongodb/src/main/java/org/jnosql/demoee/liberty/mongodb/config/ConfigTestController.java
@@ -1,4 +1,4 @@
-package org.eclipse.jnosql.demoee.liberty.mongodb.config;
+package org.jnosql.demoee.liberty.mongodb.config;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.jnosql</groupId>
+    <groupId>org.jnosql</groupId>
     <artifactId>demo-ee</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
# Changes
- Changed GroupId from `org.eclipse.jnosql.*` to `org.jnosql.*`;
- Renamed packages in order to follow the project groupId pattern;